### PR TITLE
shoulda-matchers support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/lib/minitest_rerun_failed/failed_tests_reporter.rb
+++ b/lib/minitest_rerun_failed/failed_tests_reporter.rb
@@ -65,7 +65,7 @@ module Minitest
       def find_failure_location(test, curdir)
         # Build a haystack string from failures and errors to find test file location in
         tmp_haystack = []
-        tmp_haystack << test.failure.location
+        tmp_haystack << test.source_location.join(':')
         tmp_haystack << test.to_s
         # Add filtered backtrace unless it is an unexpected error, which do not have a useful trace
         tmp_haystack << filter_backtrace(test.failure.backtrace).join unless test.failure.is_a?(Minitest::UnexpectedError)


### PR DESCRIPTION
 There was an issue where using the `should` assertions added by [should-matchers](https://github.com/thoughtbot/shoulda-matchers) one-liners.

would not record failures in minitest, and changes were made to resolve this problem.